### PR TITLE
[Feat] Agregar documentación sobre framework decisions y theming

### DIFF
--- a/docs/18_frontend_framework_decisions.md
+++ b/docs/18_frontend_framework_decisions.md
@@ -1,0 +1,114 @@
+---
+title: Frontend Framework Decisions
+layout: default
+nav_order: 18
+---
+
+# Frontend Framework Decisions: SPA, TanStack Start, and SSR
+
+Hey team! One of the first calls on a new React project is whether it needs to be a plain Vite SPA or an SSR framework — and if it needs SSR, why we reach for **TanStack Start** instead of Next.js. This doc walks through that decision, plus one case where it gets trickier in practice: Web3/wallet apps.
+
+**TanStack Start**, if you haven't used it yet, is a full-stack, SSR-capable React framework built on Vite, TanStack Router, and Nitro — the same router/query stack we already standardize on for SPAs, just with a server attached.
+
+For the broader "client-side vs server-side" business question, see [Client server side]({% link docs/2_client_server_side.md %}). For local dev setup, see [Project Setup with Vite]({% link docs/16_project_setup.md %}).
+
+## The core standard
+
+> **Does the project need SEO?**
+> - Yes → TanStack Start
+> - No → Vite SPA
+
+Within each, a second question — **is Web3 / wallet connection needed?** — determines the architecture pattern, not the framework choice.
+
+---
+
+## Web3 and SSR: why they conflict
+
+Web3 is inherently client-side. Wallets live in the browser (`window.ethereum`, injected providers, WalletConnect sessions). SSR's whole value proposition is rendering on the server. These are philosophically at odds, regardless of which SSR framework you pick.
+
+**The classic problems:**
+- Hydration mismatches — server renders with no wallet state, client renders with wallet state
+- `window is not defined` — wallet SDKs touching browser globals during SSR
+- Provider nesting — `WagmiProvider`, `QueryClientProvider`, `RainbowKitProvider` all need to stay client-only, or the app breaks on the server
+
+**TanStack Start's answer:** SSR is opt-in per route, not all-or-nothing. Public/marketing routes (landing page, FAQ, NFT gallery) render SSR as normal; wallet-dependent routes (dashboard, mint, portfolio) are marked `ssr: false` and behave like a plain SPA. Server functions and route `loader`/`beforeLoad` hooks still give SSR'd routes a backend proxy for RPC calls and allowlist gating, without the wallet providers ever needing to touch the server.
+
+---
+
+## When SSR frameworks actually make sense
+
+Beyond SEO, valid reasons to reach for an SSR framework:
+
+- **Egress optimization** — server-to-server calls on the same private network (~1ms vs ~100ms), not metered as egress, can use internal endpoints
+- **Streaming and progressive rendering** — the browser starts rendering the shell immediately while slower data fetches complete server-side
+- **First contentful paint on public pages** — HTML arrives pre-rendered rather than waiting for JS to boot
+
+**Page transitions** do not meaningfully benefit from SSR over a well-built SPA with TanStack Router or React Router — we already standardize on TanStack Router/Query for data fetching (see [Data fetching]({% link docs/5_data_fetching.md %})), so an SPA isn't giving up much here.
+
+---
+
+## TanStack Start vs Next.js
+
+TanStack Start is our preferred choice for SSR, for reasons that go beyond "no vendor lock-in":
+
+- **Simpler mental model.** Start renders components as normal, interactive React by default and you opt *into* server-only behavior. Next.js's App Router flips that: every component is a Server Component unless you add `'use client'`. For a team not already fluent in RSC, Start's default is the one that matches how React worked before Server Components existed — less to unlearn, fewer surprise client/server boundary bugs.
+- **Type safety that actually reaches the server boundary.** Start validates server functions end-to-end, inputs and outputs included. Next.js's Server Actions can receive data at runtime that TypeScript never flagged, because the type-checking stops at the client/server line.
+- **A router with compile-time guarantees, not runtime hints.** TanStack Router — the router we already standardize on — gives typed path params and validated, typed search params, with no Next.js equivalent.
+- **Caching you can reason about.** Start treats server output as ordinary data, cached through the same TanStack Query patterns we already use for client-side fetching (see [Data fetching]({% link docs/5_data_fetching.md %})). Next.js's multi-layer implicit caching (fetch cache, Router cache, Full Route cache) has a well-documented history of behaving unpredictably even for experienced teams.
+- **A standard Node.js server that fits our infra.** Start's output is a normal Node process — it drops straight into whatever AWS compute we're already using (ECS/Fargate, Elastic Beanstalk) with no framework-specific glue. Next.js *can* self-host the same way via `next start`, but several of its flagship features — ISR revalidation, Image Optimization, Edge Middleware — are built and tuned for Vercel's infrastructure; replicating them on our own AWS setup means extra plumbing (custom cache handlers, `sharp` for image processing, etc.) that Vercel gives you for free.
+
+For the full, official breakdown, see TanStack's own [Start vs Next.js comparison](https://tanstack.com/start/v0/docs/framework/react/start-vs-nextjs).
+
+---
+
+## Vite SSG
+
+An overlooked middle ground. For projects where SEO matters but content is known at build time:
+
+```javascript
+// vite.config.ts
+import prerender from 'vite-plugin-prerender'
+
+export default {
+  plugins: [
+    prerender({
+      routes: ['/about', '/pricing', '/nft/featured']
+    })
+  ]
+}
+```
+
+Outputs static HTML per route — crawlable, no server needed, deploys to S3 + CloudFront or any static host/CDN.
+
+**Covers:** routes known at build time (`/about`, `/pricing`, `/blog/post-1`)
+**Doesn't cover:** truly dynamic routes (`/nft/:contract/:tokenId` for arbitrary tokens) — those need a server-side metadata proxy, which is out of scope here.
+
+---
+
+## The decision framework
+
+```
+Does the project need SEO?
+│
+├── YES → TanStack Start
+│   └── Web3 needed?
+│       ├── No  → Full SSR, no wallet concerns
+│       └── Yes → SSR public routes; keep wallet UI client-only in the app subtree
+│
+└── NO → Vite SPA
+    └── Web3 needed?
+        ├── No  → Pure SPA, static deploy
+        └── Yes → Wallet provider at root, no SSR tension
+```
+
+---
+
+## Framework comparison summary
+
+| | Vite SPA | TanStack Start | Next.js |
+|---|---|---|---|
+| SEO / SSR | ❌ (SSG via plugin) | ✅ | ✅ |
+| Web3 compatibility | ✅ best | ✅ with `ssr:false` | ⚠️ friction |
+| AWS fit | ✅ S3 + CloudFront | ✅ ECS/Fargate, Elastic Beanstalk | ⚠️ friction |
+| Vendor lock-in | None | None | Vercel-optimized |
+| Best for | Dapps, dashboards | Hybrid SSR apps | Vercel-hosted SSR |

--- a/docs/19_tweakcn_theming.md
+++ b/docs/19_tweakcn_theming.md
@@ -1,0 +1,76 @@
+---
+title: Theming with tweakcn
+layout: default
+nav_order: 19
+---
+
+# Theming with tweakcn
+
+Hey team! We've standardized on [ShadCN/UI]({% link docs/4_styling_library.md %}) as our component library — but shadcn ships with near-default tokens, and every project that doesn't touch them ends up looking like every other shadcn site. Hand-editing OKLCH color values and spacing scales in a global CSS file to fix that burns hours we don't need to spend.
+
+This doc defines **[tweakcn](https://tweakcn.com)** as our standard for that: a visual, open-source theme editor built specifically for shadcn/ui and Tailwind CSS. It gives us real-time preview over full themes — colors, typography (including font sizes), border radius, spacing, shadows — and exports them as plain CSS variables we own. No SDK, no runtime dependency, no lock-in: if the tool disappears tomorrow, the CSS keeps working.
+
+## What tweakcn is
+
+- A **visual, no-code theme editor** for shadcn/ui on Tailwind CSS — open source ([github.com/jnsahaj/tweakcn](https://github.com/jnsahaj/tweakcn)), free for our core workflow.
+- It operates **entirely on shadcn's existing CSS variable contract** (`--primary`, `--background`, `--card`, `--radius`, `--shadow-*`, etc.) — no new abstraction on top of what shadcn already defines.
+- **Export = paste.** Output is a `:root` / `.dark` CSS variables block that drops straight into the project's global CSS — a readable, reversible, diffable block in a PR.
+
+## Why we use it: it covers more than color
+
+Beyond palettes, tweakcn gives visual control over every token shadcn exposes:
+
+| Dimension | What you can tune |
+|---|---|
+| **Color** | Background, foreground, primary/secondary/accent, card, popover, muted, destructive, border, input, ring, sidebar, chart-1..5 — light & dark independently |
+| **Radius** | Global `--radius` scale — compare sharp / soft / pill looks across all components instantly |
+| **Spacing** | Tailwind spacing properties — preview denser vs. airier layouts |
+| **Shadows** | Full shadow stack (color, opacity, blur, spread, offsets) — flat vs. elevated aesthetics |
+| **Typography** | Font family, **font size scale**, weight, letter spacing / text transform |
+
+That last row is the one to call out: when a design calls for a different type scale than shadcn's default (denser data tables, larger marketing headings, whatever the project needs), tweakcn is where we explore font sizes visually against real components instead of guessing values in `index.css`. Because everything renders live, "what if this felt more compact / rounder / flatter" becomes a five-minute experiment instead of a refactor.
+
+**Accessibility is built in** — a contrast ratio checker validates text/background pairs against WCAG before a theme ever gets exported. Treat this as a required gate: no theme ships with failing contrast pairs.
+
+## Standard workflow
+
+### New project bootstrap
+
+```bash
+npm create vite@latest my-app        # or TanStack Start when SEO matters — see [Frontend Framework Decisions]({% link docs/18_frontend_framework_decisions.md %})
+npx shadcn@latest init
+
+# Apply a theme by pasting the exported :root / .dark block into src/index.css
+```
+
+### Theme creation / iteration loop
+
+1. Open tweakcn → start from a preset close to the target, or import the project's current theme via **CSS import**.
+2. Explore palette → radius → spacing/shadows → typography (including font sizes), checking light **and** dark mode.
+3. Run the contrast checker; fix any failing pairs.
+4. Export the CSS variables block → commit it to the project's global CSS.
+5. Export the JSON preset too → commit alongside it, so the theme is reviewable and reusable across projects.
+
+### Restyling an existing project
+
+tweakcn supports **importing existing theme CSS**, so a live project's variables can be pulled into the editor, remixed, and re-exported — useful for rebrands or "refresh the look" requests without touching component code.
+
+## Limitations
+
+1. **shadcn/Tailwind only.** Projects outside the shadcn track are out of scope for this standard.
+2. **A theming layer, not a design system.** It governs tokens (color, radius, spacing, shadows, type) — component variants, iconography, motion, and content/UX guidelines still need our own conventions on top.
+3. **Typography controls are lighter** than full design-system tooling — fine for picking a font size scale, not a replacement for a full type system on brand-heavy projects.
+4. **AI theme generation is a paid feature** beyond a small free quota — treat it as an optional accelerant, not a dependency.
+
+## The rules
+
+1. Every new shadcn project applies a theme at bootstrap — no project ships stock shadcn tokens.
+2. Themes are committed to the repo as **CSS variables** (required) and, where useful, the **tweakcn JSON preset** alongside them.
+3. The contrast checker must pass before a theme is exported.
+4. Light and dark mode are both defined, always.
+
+## References
+
+- tweakcn — [tweakcn.com](https://tweakcn.com)
+- tweakcn GitHub — [github.com/jnsahaj/tweakcn](https://github.com/jnsahaj/tweakcn)
+- shadcn/ui Theming — [ui.shadcn.com/docs/theming](https://ui.shadcn.com/docs/theming)


### PR DESCRIPTION
  ## DESCRIPTION
  Adds two new standards docs to the React guidelines: a decision framework for choosing between a Vite SPA and TanStack Start (SSR) based on SEO needs, including how Web3/wallet
  requirements interact with SSR; and a standard for using tweakcn as the team's theme editor for shadcn/ui projects, covering workflow, accessibility gates, and commit rules.
  Both docs are cross-linked to existing related standards (client/server rendering, data fetching, styling library, project setup).

  ## TYPE OF CHANGE
  ◻️  Bug fix
  ◻️  New feature
  ◻️  Refactor
  🔳 Documentation
  ◻️  Tests
  ◻️  Release

  ## CHANGELOG
  - Added `docs/18_frontend_framework_decisions.md`: SPA vs TanStack Start vs Next.js decision framework, Web3/SSR conflict guidance, Vite SSG middle ground, and a framework
  comparison table.
  - Added `docs/19_tweakcn_theming.md`: standardizes tweakcn as the shadcn/ui theme editor, defines the theme creation/iteration workflow, contrast-check gate, and rules for
  committing themes to a repo.

  ## DEMO UI
  --

  ## OBSERVATIONS
  No `.github/pull_request_template.md` exists in this repo, so this description uses a standard section structure. Note: there are uncommitted local changes (modified `Gemfile`,
  `Gemfile.lock`, `docs/19_tweakcn_theming.md`, `index.md`, plus untracked `CLAUDE.md`, `frontend-framework-decisions.md`, `tweakcn-standard.md`) that are not reflected in this PR
  — commit them first if they should be included.

  ## RELATED TICKETS
  --

  ## RELATED PRs
  --